### PR TITLE
adq-patch is only for studyMode == economy

### DIFF
--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -123,5 +123,10 @@ CommandLineArguments::CommandLineArguments(uint errors) :
 {
 }
 
+IncompatibleStudyModeForAdqPatch::IncompatibleStudyModeForAdqPatch() :
+ LoadingError("Adequacy Patch can only be used with Economy Simulation Mode")
+{
+}
+
 } // namespace Error
 } // namespace Antares

--- a/src/libs/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/LoadingError.hpp
@@ -166,5 +166,12 @@ class CommandLineArguments : public LoadingError
 public:
     explicit CommandLineArguments(uint errors);
 };
+
+class IncompatibleStudyModeForAdqPatch : public LoadingError
+{
+public:
+    IncompatibleStudyModeForAdqPatch();
+};
+
 } // namespace Error
 } // namespace Antares

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -84,6 +84,16 @@ void checkSimplexRangeHydroHeuristic(Antares::Data::SimplexOptimization optRange
     }
 }
 
+// Adequacy Patch can only be used with Economy Study/Simulation Mode.
+void checkAdqPatchStudyModeEconomuOnly(const bool adqPatchOn,
+                                       const Antares::Data::StudyMode studyMode)
+{
+    if ((studyMode != Antares::Data::StudyMode::stdmEconomy) && adqPatchOn)
+    {
+        throw Error::IncompatibleStudyModeForAdqPatch();
+    }
+}
+
 void checkMinStablePower(bool tsGenThermal, const Antares::Data::AreaList& areas)
 {
     if (tsGenThermal)
@@ -238,6 +248,8 @@ void Application::prepare(int argc, char* argv[])
                                         pParameters->unitCommitment.ucMode);
 
     checkSimplexRangeHydroHeuristic(pParameters->simplexOptimizationRange, pStudy->areas);
+
+    checkAdqPatchStudyModeEconomuOnly(pParameters->include.adequacyPatch, pParameters->mode);
 
     bool tsGenThermal = (0
                          != (pStudy->parameters.timeSeriesToGenerate


### PR DESCRIPTION
When I run study in adequacy or draft mode with adq patch off, everything works fine. But when you run study in adequacy or draft mode with adq patch on, simulation breaks and reports error. As per Florian's last comment we should just report our error that this option/combination is not possible! 