### PR TITLE
Add GUI option to set CSR variable bounds relaxation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set(ANTARES_WEBSITE "https://antares.rte-france.com")
 set(ANTARES_ONLINE_DOC "https://antares-simulator.readthedocs.io/")
 
 # Beta release
-set(ANTARES_BETA 0)
+set(ANTARES_BETA 7)
 set(ANTARES_RC 0)
 
 # OR-Tools tag

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -695,7 +695,7 @@ static bool SGDIntLoadFamily_AdqPatch(Parameters& d,
     if (key == "threshold-display-local-matching-rule-violations")
         return value.to<double>(d.adqPatch.curtailmentSharing.thresholdDisplayViolations);
     if (key == "threshold-csr-variable-bounds-relaxation")
-        return value.to<double>(d.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation);
+        return value.to<int>(d.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation);
 
     return false;
 }

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -242,6 +242,8 @@ void Parameters::resetThresholdsAdqPatch()
       = defaultValueThresholdInitiateCurtailmentSharingRule;
     adqPatch.curtailmentSharing.thresholdDisplayViolations
       = defaultValueThresholdDisplayLocalMatchingRuleViolations;
+    adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation
+      = defaultValueThresholdVarBoundsRelaxation;
 }
 
 void Parameters::resetAdqPatchParameters()
@@ -689,9 +691,11 @@ static bool SGDIntLoadFamily_AdqPatch(Parameters& d,
         return value.to<bool>(d.adqPatch.curtailmentSharing.includeHurdleCost);
     // Thresholds
     if (key == "threshold-initiate-curtailment-sharing-rule")
-        return value.to<float>(d.adqPatch.curtailmentSharing.thresholdInitiate);
+        return value.to<double>(d.adqPatch.curtailmentSharing.thresholdInitiate);
     if (key == "threshold-display-local-matching-rule-violations")
-        return value.to<float>(d.adqPatch.curtailmentSharing.thresholdDisplayViolations);
+        return value.to<double>(d.adqPatch.curtailmentSharing.thresholdDisplayViolations);
+    if (key == "threshold-csr-variable-bounds-relaxation")
+        return value.to<double>(d.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation);
 
     return false;
 }
@@ -1826,6 +1830,8 @@ void Parameters::saveToINI(IniFile& ini) const
                      adqPatch.curtailmentSharing.thresholdInitiate);
         section->add("threshold-display-local-matching-rule-violations",
                      adqPatch.curtailmentSharing.thresholdDisplayViolations);
+        section->add("threshold-csr-variable-bounds-relaxation",
+                     adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation);
     }
 
     // Other preferences

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -538,7 +538,7 @@ public:
             //! Threshold to display Local Matching Rule violations
             double thresholdDisplayViolations;
             //! CSR Variables relaxation threshold
-            double thresholdVarBoundsRelaxation;
+            int thresholdVarBoundsRelaxation;
             //! Include hurdle cost in CSR cost function
             bool includeHurdleCost;
         };

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -534,9 +534,11 @@ public:
             //! PTO (Price Taking Order) for adequacy patch. User can choose between DENS and Load.
             Data::AdequacyPatch::AdqPatchPTO priceTakingOrder;
             //! Threshold to initiate curtailment sharing rule
-            float thresholdInitiate;
+            double thresholdInitiate;
             //! Threshold to display Local Matching Rule violations
-            float thresholdDisplayViolations;
+            double thresholdDisplayViolations;
+            //! CSR Variables relaxation threshold
+            double thresholdVarBoundsRelaxation;
             //! Include hurdle cost in CSR cost function
             bool includeHurdleCost;
         };

--- a/src/solver/optimisation/adequacy_patch.h
+++ b/src/solver/optimisation/adequacy_patch.h
@@ -42,7 +42,7 @@ const double defaultValueThresholdInitiateCurtailmentSharingRule = 0.0;
 //! A default threshold value for display local matching rule violations
 const double defaultValueThresholdDisplayLocalMatchingRuleViolations = 0.0;
 //! CSR Variables relaxation threshold
-const double defaultValueThresholdVarBoundsRelaxation = 1e-3;
+const int defaultValueThresholdVarBoundsRelaxation = 3;
 /*!
  * Determines restriction type for transmission links for first step of adequacy patch.
  *

--- a/src/solver/optimisation/adequacy_patch.h
+++ b/src/solver/optimisation/adequacy_patch.h
@@ -42,7 +42,7 @@ const double defaultValueThresholdInitiateCurtailmentSharingRule = 0.0;
 //! A default threshold value for display local matching rule violations
 const double defaultValueThresholdDisplayLocalMatchingRuleViolations = 0.0;
 //! CSR Variables relaxation threshold
-const double defaultValueThresholdVarBoundsRelaxation = 1e-5;
+const double defaultValueThresholdVarBoundsRelaxation = 1e-3;
 /*!
  * Determines restriction type for transmission links for first step of adequacy patch.
  *

--- a/src/solver/optimisation/adequacy_patch.h
+++ b/src/solver/optimisation/adequacy_patch.h
@@ -41,6 +41,8 @@ namespace AdequacyPatch
 const double defaultValueThresholdInitiateCurtailmentSharingRule = 0.0;
 //! A default threshold value for display local matching rule violations
 const double defaultValueThresholdDisplayLocalMatchingRuleViolations = 0.0;
+//! CSR Variables relaxation threshold
+const double defaultValueThresholdVarBoundsRelaxation = 1e-5;
 /*!
  * Determines restriction type for transmission links for first step of adequacy patch.
  *

--- a/src/solver/optimisation/adequacy_patch_csr/construct_problem_constraints_RHS.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/construct_problem_constraints_RHS.cpp
@@ -30,8 +30,6 @@
 #include "../solver/simulation/sim_extern_variables_globales.h"
 #include "../solver/optimisation/opt_fonctions.h"
 
-const double csrSolverRelaxationRHS = 1e-3;
-
 void setRHSvalueOnFlows(PROBLEME_HEBDO* ProblemeHebdo, HOURLY_CSR_PROBLEM& hourlyCsrProblem)
 {
     int Cnt;
@@ -96,6 +94,7 @@ void setRHSbindingConstraintsValue(PROBLEME_HEBDO* ProblemeHebdo,
                                    const HOURLY_CSR_PROBLEM& hourlyCsrProblem)
 {
     int hour = hourlyCsrProblem.hourInWeekTriggeredCsr;
+    double csrSolverRelaxationRHS = ProblemeHebdo->adqPatchParams->ThresholdCSRVarBoundsRelaxation;
     int Cnt;
     int Interco;
     int NbInterco;

--- a/src/solver/optimisation/adequacy_patch_csr/set_variable_boundaries.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/set_variable_boundaries.cpp
@@ -38,7 +38,6 @@
 #include <math.h>
 #include <yuni/core/math.h>
 
-const double csrSolverRelaxation = 1e-3;
 using namespace Yuni;
 
 void setBoundsOnENS(PROBLEME_HEBDO* ProblemeHebdo, HOURLY_CSR_PROBLEM& hourlyCsrProblem)
@@ -51,6 +50,7 @@ void setBoundsOnENS(PROBLEME_HEBDO* ProblemeHebdo, HOURLY_CSR_PROBLEM& hourlyCsr
     ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
     const CORRESPONDANCES_DES_VARIABLES* CorrespondanceVarNativesVarOptim;
     CorrespondanceVarNativesVarOptim = ProblemeHebdo->CorrespondanceVarNativesVarOptim[hour];
+    double csrSolverRelaxation = ProblemeHebdo->adqPatchParams->ThresholdCSRVarBoundsRelaxation;
 
     // variables: ENS for each area inside adq patch
     for (int area = 0; area < ProblemeHebdo->NombreDePays; ++area)
@@ -61,7 +61,8 @@ void setBoundsOnENS(PROBLEME_HEBDO* ProblemeHebdo, HOURLY_CSR_PROBLEM& hourlyCsr
             Var = CorrespondanceVarNativesVarOptim->NumeroDeVariableDefaillancePositive[area];
 
             ProblemeAResoudre->Xmin[Var] = -csrSolverRelaxation;
-            ProblemeAResoudre->Xmax[Var] = hourlyCsrProblem.densNewValues[area] + csrSolverRelaxation;
+            ProblemeAResoudre->Xmax[Var]
+              = hourlyCsrProblem.densNewValues[area] + csrSolverRelaxation;
 
             ProblemeAResoudre->X[Var]
               = ProblemeHebdo->ResultatsHoraires[area]->ValeursHorairesDeDefaillancePositive[hour];
@@ -82,7 +83,8 @@ void setBoundsOnENS(PROBLEME_HEBDO* ProblemeHebdo, HOURLY_CSR_PROBLEM& hourlyCsr
     }
 }
 
-void setBoundsOnSpilledEnergy(PROBLEME_HEBDO* ProblemeHebdo, const HOURLY_CSR_PROBLEM& hourlyCsrProblem)
+void setBoundsOnSpilledEnergy(PROBLEME_HEBDO* ProblemeHebdo,
+                              const HOURLY_CSR_PROBLEM& hourlyCsrProblem)
 {
     int Var;
     double* AdresseDuResultat;
@@ -92,6 +94,7 @@ void setBoundsOnSpilledEnergy(PROBLEME_HEBDO* ProblemeHebdo, const HOURLY_CSR_PR
     ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
     const CORRESPONDANCES_DES_VARIABLES* CorrespondanceVarNativesVarOptim;
     CorrespondanceVarNativesVarOptim = ProblemeHebdo->CorrespondanceVarNativesVarOptim[hour];
+    double csrSolverRelaxation = ProblemeHebdo->adqPatchParams->ThresholdCSRVarBoundsRelaxation;
 
     // variables: Spilled Energy for each area inside adq patch
     for (int area = 0; area < ProblemeHebdo->NombreDePays; ++area)
@@ -125,6 +128,7 @@ void setBoundsOnFlows(PROBLEME_HEBDO* ProblemeHebdo, const HOURLY_CSR_PROBLEM& h
     double* AdresseDuResultat;
     int hour;
     hour = hourlyCsrProblem.hourInWeekTriggeredCsr;
+    double csrSolverRelaxation = ProblemeHebdo->adqPatchParams->ThresholdCSRVarBoundsRelaxation;
     PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre;
     ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
     const CORRESPONDANCES_DES_VARIABLES* CorrespondanceVarNativesVarOptim;
@@ -149,8 +153,10 @@ void setBoundsOnFlows(PROBLEME_HEBDO* ProblemeHebdo, const HOURLY_CSR_PROBLEM& h
         {
             // flow
             Var = CorrespondanceVarNativesVarOptim->NumeroDeVariableDeLInterconnexion[Interco];
-            Xmax[Var] = ValeursDeNTC->ValeurDeNTCOrigineVersExtremite[Interco] + csrSolverRelaxation;
-            Xmin[Var] = -(ValeursDeNTC->ValeurDeNTCExtremiteVersOrigine[Interco]) - csrSolverRelaxation;
+            Xmax[Var]
+              = ValeursDeNTC->ValeurDeNTCOrigineVersExtremite[Interco] + csrSolverRelaxation;
+            Xmin[Var]
+              = -(ValeursDeNTC->ValeurDeNTCExtremiteVersOrigine[Interco]) - csrSolverRelaxation;
             ProblemeAResoudre->X[Var] = ValeursDeNTC->ValeurDuFlux[Interco];
 
             if (Math::Infinite(Xmax[Var]) == 1)
@@ -180,7 +186,8 @@ void setBoundsOnFlows(PROBLEME_HEBDO* ProblemeHebdo, const HOURLY_CSR_PROBLEM& h
                     ->NumeroDeVariableCoutOrigineVersExtremiteDeLInterconnexion[Interco];
 
             Xmin[Var] = -csrSolverRelaxation;
-            Xmax[Var] = ValeursDeNTC->ValeurDeNTCOrigineVersExtremite[Interco] + csrSolverRelaxation;
+            Xmax[Var]
+              = ValeursDeNTC->ValeurDeNTCOrigineVersExtremite[Interco] + csrSolverRelaxation;
             ProblemeAResoudre->TypeDeVariable[Var] = VARIABLE_BORNEE_DES_DEUX_COTES;
             if (Math::Infinite(Xmax[Var]) == 1)
             {
@@ -194,7 +201,8 @@ void setBoundsOnFlows(PROBLEME_HEBDO* ProblemeHebdo, const HOURLY_CSR_PROBLEM& h
                     ->NumeroDeVariableCoutExtremiteVersOrigineDeLInterconnexion[Interco];
 
             Xmin[Var] = -csrSolverRelaxation;
-            Xmax[Var] = ValeursDeNTC->ValeurDeNTCExtremiteVersOrigine[Interco] + csrSolverRelaxation;
+            Xmax[Var]
+              = ValeursDeNTC->ValeurDeNTCExtremiteVersOrigine[Interco] + csrSolverRelaxation;
             ProblemeAResoudre->TypeDeVariable[Var] = VARIABLE_BORNEE_DES_DEUX_COTES;
             if (Math::Infinite(Xmax[Var]) == 1)
             {

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -80,8 +80,8 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
           = parameters.adqPatch.curtailmentSharing.thresholdInitiate;
         problem.adqPatchParams->ThresholdDisplayLocalMatchingRuleViolations
           = parameters.adqPatch.curtailmentSharing.thresholdDisplayViolations;
-        problem.adqPatchParams->ThresholdCSRVarBoundsRelaxation
-          = parameters.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation;
+        double temp = pow(10, -parameters.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation);
+        problem.adqPatchParams->ThresholdCSRVarBoundsRelaxation = temp < 0.1 ? temp : 0.1;
 
         problem.adequacyPatchRuntimeData.initialize(study);
     }

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -80,6 +80,8 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
           = parameters.adqPatch.curtailmentSharing.thresholdInitiate;
         problem.adqPatchParams->ThresholdDisplayLocalMatchingRuleViolations
           = parameters.adqPatch.curtailmentSharing.thresholdDisplayViolations;
+        problem.adqPatchParams->ThresholdCSRVarBoundsRelaxation
+          = parameters.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation;
 
         problem.adequacyPatchRuntimeData.initialize(study);
     }

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -502,6 +502,7 @@ struct AdequacyPatchParameters
     AdqPatchPTO PriceTakingOrder;
     double ThresholdInitiateCurtailmentSharingRule;
     double ThresholdDisplayLocalMatchingRuleViolations;
+    double ThresholdCSRVarBoundsRelaxation;
 };
 
 struct PROBLEME_HEBDO
@@ -730,12 +731,14 @@ public:
     void run(uint week, int year);
     
     int hourInWeekTriggeredCsr;
-    const double belowThisThresholdSetToZero = 1e-3;
+    double belowThisThresholdSetToZero;
     PROBLEME_HEBDO* pWeeklyProblemBelongedTo;
     HOURLY_CSR_PROBLEM(int hourInWeek, PROBLEME_HEBDO* pProblemeHebdo)
     {
         hourInWeekTriggeredCsr = hourInWeek;
         pWeeklyProblemBelongedTo = pProblemeHebdo;
+        belowThisThresholdSetToZero
+          = pProblemeHebdo->adqPatchParams->ThresholdCSRVarBoundsRelaxation;
     };
     std::map<int, int> numberOfConstraintCsrEns;
     std::map<int, int> numberOfConstraintCsrAreaBalance;

--- a/src/ui/simulator/windows/options/adequacy-patch/adequacy-patch-options.cpp
+++ b/src/ui/simulator/windows/options/adequacy-patch/adequacy-patch-options.cpp
@@ -240,7 +240,7 @@ AdequacyPatchOptions::AdequacyPatchOptions(wxWindow* parent) :
         pThresholdCSRVarBoundsRelaxation
           = insertEdit(this,
                        s,
-                       wxStringFromUTF8("Relax CSR variable boundaries"),
+                       wxStringFromUTF8("Relax CSR variable boundaries (10^-)"),
                        wxCommandEventHandler(AdequacyPatchOptions::onEditThresholds));
     }
 
@@ -594,11 +594,11 @@ void AdequacyPatchOptions::onEditThresholds(wxCommandEvent& evt)
         String text;
         wxStringToString(pThresholdCSRVarBoundsRelaxation->GetValue(), text);
 
-        float newthreshold;
+        int newthreshold;
         if (!text.to(newthreshold))
         {
             logs.error() << "impossible to update the seed for '"
-                         << "Relax CSR variable boundaries"
+                         << "Relax CSR variable boundaries (10^-)"
                          << "'";
         }
         else

--- a/src/ui/simulator/windows/options/adequacy-patch/adequacy-patch-options.cpp
+++ b/src/ui/simulator/windows/options/adequacy-patch/adequacy-patch-options.cpp
@@ -226,6 +226,7 @@ AdequacyPatchOptions::AdequacyPatchOptions(wxWindow* parent) :
     {
         pThresholdCSRStart = nullptr;
         pThresholdLMRviolations = nullptr;
+        pThresholdCSRVarBoundsRelaxation = nullptr;
         pThresholdCSRStart
           = insertEdit(this,
                        s,
@@ -235,6 +236,11 @@ AdequacyPatchOptions::AdequacyPatchOptions(wxWindow* parent) :
           = insertEdit(this,
                        s,
                        wxStringFromUTF8("Display local matching rule violations"),
+                       wxCommandEventHandler(AdequacyPatchOptions::onEditThresholds));
+        pThresholdCSRVarBoundsRelaxation
+          = insertEdit(this,
+                       s,
+                       wxStringFromUTF8("Relax CSR variable boundaries"),
                        wxCommandEventHandler(AdequacyPatchOptions::onEditThresholds));
     }
 
@@ -360,7 +366,12 @@ void AdequacyPatchOptions::refresh()
               wxString() << study.parameters.adqPatch.curtailmentSharing.thresholdInitiate);
         if (pThresholdLMRviolations)
             pThresholdLMRviolations->SetValue(
-              wxString() << study.parameters.adqPatch.curtailmentSharing.thresholdDisplayViolations);
+              wxString()
+              << study.parameters.adqPatch.curtailmentSharing.thresholdDisplayViolations);
+        if (pThresholdCSRVarBoundsRelaxation)
+            pThresholdCSRVarBoundsRelaxation->SetValue(
+              wxString()
+              << study.parameters.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation);
     }
 }
 
@@ -577,6 +588,30 @@ void AdequacyPatchOptions::onEditThresholds(wxCommandEvent& evt)
         }
         return;
     }
-}
 
+    if (pThresholdCSRVarBoundsRelaxation && id == pThresholdCSRVarBoundsRelaxation->GetId())
+    {
+        String text;
+        wxStringToString(pThresholdCSRVarBoundsRelaxation->GetValue(), text);
+
+        float newthreshold;
+        if (!text.to(newthreshold))
+        {
+            logs.error() << "impossible to update the seed for '"
+                         << "Relax CSR variable boundaries"
+                         << "'";
+        }
+        else
+        {
+            if (newthreshold
+                != study.parameters.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation)
+            {
+                study.parameters.adqPatch.curtailmentSharing.thresholdVarBoundsRelaxation
+                  = newthreshold;
+                MarkTheStudyAsModified();
+            }
+        }
+        return;
+    }
 }
+} // namespace Antares::Window::Options

--- a/src/ui/simulator/windows/options/adequacy-patch/adequacy-patch-options.h
+++ b/src/ui/simulator/windows/options/adequacy-patch/adequacy-patch-options.h
@@ -92,6 +92,7 @@ private:
     Component::Button* pBtnAdequacyPatchIncludeHurdleCostCsr;
     wxTextCtrl* pThresholdCSRStart;
     wxTextCtrl* pThresholdLMRviolations;
+    wxTextCtrl* pThresholdCSRVarBoundsRelaxation;
     bool* pTargetRef;
 
 }; // class AdequacyPatchOptions


### PR DESCRIPTION
Ok. This GUI was demanded by Daniel/Elia at today's meeting, so he can run some tests. 
This pr going to https://github.com/AntaresSimulatorTeam/Antares_Simulator/tree/feature/do-not-merge-csr-generate-executables for creating the beta7 version,  to be sent to Daniel for his tests. 
We'll see if it's going to be part of the final solution. Most probably not.